### PR TITLE
Merge repository initialiation commits from W3C repo

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+All documentation, code and communication under this repository are covered by the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+All documents in this Repository are licensed by contributors
+under the 
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# font-text.github.io
-GitHub Pages
+# font-text-cg
+
+GitHub repo for the [W3C Font and Text Community Group](https://www.w3.org/community/font-text/)

--- a/w3c.json
+++ b/w3c.json
@@ -1,0 +1,5 @@
+{
+    "group":     125655
+,   "contacts":  "svgeesus"
+,   "repo-type": "process"
+}


### PR DESCRIPTION
At the last CG meeting (notes in [this Google doc](https://docs.google.com/document/d/1KoknOb0IMAPeiLhifvc_AqB7s3rs6VKOsTQg_oCDypQ/edit?usp=sharing)) a decision was made to place a repository under the W3C org namespace:

> RESOLVED: Create repo under W3C organization e.g. w3c/font-text
> ACTION: Chris Lilley to create w3c/font-text (and migrate the issues if possible) within 3 days

This was promptly spun up by @svgeesus as a new repository `w3c/font-text-cg`. However as we already have some history include edits and lots of comments on our draft charter in this repository, I proposed [here](https://github.com/w3c/font-text-cg/issues/1) (link may go dead shortly if my proposal is accepted) that *this* repository be transferred instead to retain that history.

> Before this repo goes any farther, can I propose that we ⓐ rename & archive or delete this repo out of the way, then ⓑ transfer this repo into this org namespace, then ⓒ rename it as appropriate, then ⓓ cherry pick the commits to this repo to the other one to bring it up to speed with the code of conduct, etc. This will best preserve the edit and comment history to the charter which I believe is significant.

This PR contains all the content as committed to the other repository rebased on this one so that no good work goes to waste. This is effectively the ⓓ part of my proposal ready made.

This can be merged before or after transferring and renaming the repository, it doesn't matter.