### PR TITLE
Link to charter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-# font-text-cg
+# Font and Text Community Group
 
-GitHub repo for the [W3C Font and Text Community Group](https://www.w3.org/community/font-text/)
+This is the GitHub repository for the [W3C Font and Text Community Group](https://www.w3.org/community/font-text/).
+The [issue tracker](https://github.com/w3c/font-text-cg/issues) is the primary venue for discussions.
+Read this [Community Group's Charter](https://w3c.github.io/font-text-cg/charter/).
+

--- a/charter/index.md
+++ b/charter/index.md
@@ -7,7 +7,7 @@ title: Font and Text Community Group Charter
  - Last Modified: *October 4th, 2020*
 
 Submit feedback:
-https://github.com/w3c/font-text-cg/issues
+[GitHub Issues](https://github.com/w3c/font-text-cg/issues)
 
 ## Goals
 
@@ -227,4 +227,4 @@ may take any action including no action.
 
 This charter can be amended by the Chair(s)
 with consultation of the Community Group,
-if the change is agreed to by W3C’s Community Development Lead
+if the change is agreed to by W3C’s Community Development Lead.


### PR DESCRIPTION
This adds relevant links to the README such that visitors to the GitHub Pages hoste site ([https://w3c.github.io/font-text-cg/](https://w3c.github.io/font-text-cg/)) can navigate to the charter and issue tracker. The charter is rendered for the site already but there is no link to it.