### PR TITLE
Add blank document and crosslinks for work-items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Font and Text Community Group
 
 This is the GitHub repository for the [W3C Font and Text Community Group](https://www.w3.org/community/font-text/).
-The [issue tracker](https://github.com/w3c/font-text-cg/issues) is the primary venue for discussions.
 Read this [Community Group's Charter](https://w3c.github.io/font-text-cg/charter/).
 
+* See the [issue tracker](https://github.com/w3c/font-text-cg/issues/), the primary venue for CG discussions.
+* See [work items](https://w3c.github.io/font-text-cg/work-items/) for an index of documents being worked on.

--- a/work-items/index.md
+++ b/work-items/index.md
@@ -1,0 +1,5 @@
+---
+title: Font and Text Community Group Work Items
+---
+
+# Work Items

--- a/work-items/index.md
+++ b/work-items/index.md
@@ -3,3 +3,5 @@ title: Font and Text Community Group Work Items
 ---
 
 # Work Items
+
+See the [work-items diretory](https://github.com/w3c/font-text-cg/tree/main/work-items)


### PR DESCRIPTION
Our charter mentions and links to this document, but it as of yet it hasn't existed. For the ease of people wanting to add items to it (see e.g. [this potential work item](https://github.com/w3c/font-text-cg/issues/8#issuecomment-704767417)) here is the blank template and links necessary to get to it.